### PR TITLE
FEAT: GITHUB LOGIN ADDED

### DIFF
--- a/decide/authentication/fixtures/initial_data.json
+++ b/decide/authentication/fixtures/initial_data.json
@@ -18,5 +18,17 @@
       "key":"",
       "sites": [1]
     }
+  },
+  {
+    "model": "socialaccount.socialapp", 
+    "pk": 2, 
+    "fields": {
+      "provider": "github",
+      "name": "GitHub-OAuth",
+      "client_id":"9e679d98f86cfc3f1de5",
+      "secret":"87ba4ec0041035939bf67a4a2e3813172492001f",
+      "key":"",
+      "sites": [1]
+    }
   }
 ]

--- a/decide/decide/settings.py
+++ b/decide/decide/settings.py
@@ -50,6 +50,7 @@ INSTALLED_APPS = [
     'allauth.account',
     'allauth.socialaccount',
     'allauth.socialaccount.providers.google',
+    'allauth.socialaccount.providers.github',
 ]
 
 REST_FRAMEWORK = {
@@ -72,6 +73,7 @@ SOCIALACCOUNT_QUERY_EMAIL = True
 ACCOUNT_LOGOUT_ON_GET= True
 ACCOUNT_UNIQUE_EMAIL = True
 ACCOUNT_EMAIL_REQUIRED = True
+ACCOUNT_EMAIL_VERIFICATION = 'none'
 
 SOCIALACCOUNT_PROVIDERS = {
     'google': {
@@ -84,6 +86,13 @@ SOCIALACCOUNT_PROVIDERS = {
         },
         'OAUTH_PKCE_ENABLED': True,
     },
+    'github': {
+        'SCOPE': [
+            'user',
+            'repo',
+            'read:org',
+        ],
+    }
 }
 
 MODULES = [

--- a/decide/visualizer/templates/signin.html
+++ b/decide/visualizer/templates/signin.html
@@ -25,7 +25,7 @@
 
   <br>
   <p>Don't have an account? <a href="{% url 'signup' %}">Register now</a></p>
-  <p>You can also sign in with: <a href="{% provider_login_url 'google' %}">Google</a></p>
+  <p>You can also sign in with: <a href="{% provider_login_url 'google' %}">Google</a>, <a href="{% provider_login_url 'github' %}">GitHub</a></p>
 </div>
 
 


### PR DESCRIPTION
The alternative login using the github social account has been implemented.
(Closes #60) 