### PR TITLE
FEAT: URL Reset

### DIFF
--- a/decide/authentication/views.py
+++ b/decide/authentication/views.py
@@ -147,8 +147,10 @@ class SignInView(APIView):
     
     @staticmethod     
     def sing_in(request):
+        print(request)
 
-        if request.user.is_authenticated:
+        if request.user.is_authenticated and request.GET != "/": 
+            
             return redirect('hello')
 
         if request.method == 'GET':

--- a/decide/decide/urls.py
+++ b/decide/decide/urls.py
@@ -17,11 +17,13 @@ from django.conf import settings
 from django.contrib import admin
 from django.urls import path, include
 from rest_framework_swagger.views import get_swagger_view
+from authentication.views import SignInView
 
 
 schema_view = get_swagger_view(title='Decide API')
 
 urlpatterns = [
+    path('',SignInView.sing_in),
     path('admin/', admin.site.urls),
     path('doc/', schema_view),
     path('gateway/', include('gateway.urls')),


### PR DESCRIPTION
The login page has been set as the root of the project if the user is not logged in. Otherwise, the root of the project is the user greeting page.